### PR TITLE
Store missing keymap for unregistering, and small style cleanup

### DIFF
--- a/scene_stroll.py
+++ b/scene_stroll.py
@@ -72,6 +72,7 @@ def scene_stroll_ui(self, context):
         text="Next",
         icon='FORWARD')
 
+
 addon_keymaps = []
 
 def register():
@@ -82,20 +83,24 @@ def register():
     kc = wm.keyconfigs.addon
     if kc:
         km = kc.keymaps.new(name='Window')
+
         kmi = km.keymap_items.new('scene.stroll', 'LEFT_ARROW', 'PRESS', shift=True, ctrl=True)
         kmi.properties.next = False
-        kmi = km.keymap_items.new('scene.stroll', 'RIGHT_ARROW', 'PRESS', shift=True, ctrl=True)
-        kmi.properties.next = True
-
         addon_keymaps.append((km, kmi))
 
-def unregister():
-    bpy.utils.unregister_class(SCENE_OT_stroll)
-    bpy.types.SCENE_PT_scene.remove(scene_stroll_ui)
+        kmi = km.keymap_items.new('scene.stroll', 'RIGHT_ARROW', 'PRESS', shift=True, ctrl=True)
+        kmi.properties.next = True
+        addon_keymaps.append((km, kmi))
 
+
+def unregister():
     for km, kmi in addon_keymaps:
         km.keymap_items.remove(kmi)
     addon_keymaps.clear()
+
+    bpy.types.SCENE_PT_scene.remove(scene_stroll_ui)
+    bpy.utils.unregister_class(SCENE_OT_stroll)
+
 
 if __name__ == "__main__":
     register()


### PR DESCRIPTION
Hey Pablo, this doesn't fix the 'prints when unregistering' issue, but you were forgetting to append one of the keymap_items.

Also, it's a good practise to unregister things in the reverse order of registering (not sure if Blender does that, but I do it all the time, and I remember correctly you may run into bugs otherwise). 

Finally pep8 suggests 2-white lines between top-level functions/class declarations (class functions have 1 line separation though).
